### PR TITLE
Added queueId to id param of item in DIDL-lite in QueueTrack

### DIFF
--- a/src/Tracks/QueueTrack.php
+++ b/src/Tracks/QueueTrack.php
@@ -31,4 +31,13 @@ class QueueTrack extends Track
 
         return $track;
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function getMetaData()
+    {
+        $meta=parent::getMetaData(($this->queueId ? $this->queueId : "-1"));
+        return $meta;
+    }
 }

--- a/src/Tracks/Track.php
+++ b/src/Tracks/Track.php
@@ -67,9 +67,10 @@ class Track implements UriInterface
     /**
      * Get the metadata xml for this track.
      *
+     * @param string $queueId
      * @return string
      */
-    public function getMetaData()
+    public function getMetaData($queueId = "-1")
     {
         $xml = XmlWriter::createXml([
             "DIDL-Lite" =>  [

--- a/src/Tracks/Track.php
+++ b/src/Tracks/Track.php
@@ -82,7 +82,7 @@ class Track implements UriInterface
                 ],
                 "item"  =>  [
                     "_attributes"   =>  [
-                        "id"            =>  "-1",
+                        "id"            =>  $queueId,
                         "parentID"      =>  "-1",
                         "restricted"    =>  "true",
                     ],


### PR DESCRIPTION
Solves issue where Metadata is missing when adding track from playlist.

Hi Craig,
Bumped in to this issue [https://github.com/duncan3dc/sonos/issues/18] and tried to solve it.
Here is my solution. Use it if you like.

Btw, thanks for a great job done!
Best regards,
Magnus Ahlstrom