### PR TITLE
Added possibility to specify broadcast IP for network discovery

### DIFF
--- a/src/Network.php
+++ b/src/Network.php
@@ -40,14 +40,19 @@ class Network implements LoggerAwareInterface
      */
     protected $logger;
 
+    /**
+     * @var string $broadcastIp ip being used to send the broadcast to
+     */
+    protected $broadcastIp = '239.255.255.250';
 
     /**
      * Create a new instance.
      *
      * @param CacheInterface $cache The cache object to use for the expensive multicast discover to find Sonos devices on the network
      * @param LoggerInterface $logger The logging object
+     * @param string $broadcastIp ip being used to send the broadcast to
      */
-    public function __construct(CacheInterface $cache = null, LoggerInterface $logger = null)
+    public function __construct(CacheInterface $cache = null, LoggerInterface $logger = null, $broadcastIp = null)
     {
         if ($cache === null) {
             $cache = new Cache;
@@ -58,6 +63,9 @@ class Network implements LoggerAwareInterface
             $logger = new NullLogger;
         }
         $this->logger = $logger;
+        if ($broadcastIp != null) {
+            $this->broadcastIp = $broadcastIp;
+        }
     }
 
 
@@ -96,7 +104,7 @@ class Network implements LoggerAwareInterface
     {
         $this->logger->info("discovering devices...");
 
-        $ip = "239.255.255.250";
+        $ip = $this->broadcastIp;
         $port = 1900;
 
         $sock = socket_create(AF_INET, SOCK_DGRAM, SOL_UDP);

--- a/src/Network.php
+++ b/src/Network.php
@@ -52,7 +52,7 @@ class Network implements LoggerAwareInterface
      * @param LoggerInterface $logger The logging object
      * @param string $broadcastIp ip being used to send the broadcast to
      */
-    public function __construct(CacheInterface $cache = null, LoggerInterface $logger = null, $broadcastIp = null)
+    public function __construct(CacheInterface $cache = null, LoggerInterface $logger = null)
     {
         if ($cache === null) {
             $cache = new Cache;
@@ -63,11 +63,22 @@ class Network implements LoggerAwareInterface
             $logger = new NullLogger;
         }
         $this->logger = $logger;
-        if ($broadcastIp != null) {
-            $this->broadcastIp = $broadcastIp;
-        }
     }
 
+
+    /**
+     * Set the IP address being used for broadcasting
+     *
+     * @var string $broadcastIp ip of broadcast
+     *
+     * @return static
+     */
+    public function setBroadcastIp($broadcastIp)
+    {
+        $this->broadcastIp = $broadcastIp;
+
+        return $this;
+    }
 
     /**
      * Set the logger object to use.


### PR DESCRIPTION
in case the speaker have a different subnetwork it might be necessary to specify a different broadcast ip address - this pull request makes it possible to specify this as additional parameter when instantiating the network class.