### PR TITLE
Fix invalid usage of $queue

### DIFF
--- a/src/Controller.php
+++ b/src/Controller.php
@@ -639,7 +639,7 @@ class Controller extends Speaker
         $queue = $this->getQueue();
         $queue->clear();
         if (count($state->tracks) > 0) {
-            $queue()->addTracks($state->tracks);
+            $queue->addTracks($state->tracks);
         }
 
         if (count($state->tracks) > 0) {


### PR DESCRIPTION
instead of the variable $queue, $queue() (with usage of "(" and ")") had been called - and resulted in an error.