### PR TITLE
Added ability to get the network interface name

### DIFF
--- a/src/Network.php
+++ b/src/Network.php
@@ -128,6 +128,16 @@ class Network implements LoggerAwareInterface
         return $this;
     }
 
+    /**
+     * Get the network interface currently in use
+     *
+     * @return string The network interface name
+     */
+    public function getNetworkInterface()
+    {
+        return $this->networkInterface;
+    }
+
 
     protected function getCacheKey()
     {


### PR DESCRIPTION
Sometimes it is useful to know which network interface is being
used, perhaps for troubleshooting, or to do different things
based on the connected network etc.