### PR TITLE
Add getter for class-attribute network

### DIFF
--- a/src/Controller.php
+++ b/src/Controller.php
@@ -774,4 +774,12 @@ class Controller extends Speaker
 
         return $this;
     }
+
+    /**
+     * @return Network
+     */
+    public function getNetwork()
+    {
+        return $this->network;
+    }
 }


### PR DESCRIPTION
I'm passing the controller as a parameter to a method. Instead of additionally passing the $sonos Network class, it might be convenient to fetch the class from the Controller.