### PR TITLE
* Added model S12 for new Play:1's (purchased Nov '16)

### DIFF
--- a/src/Device.php
+++ b/src/Device.php
@@ -176,6 +176,7 @@ class Device
             "S5"    =>  "PLAY:5",
             "S6"    =>  "PLAY:5",
             "S9"    =>  "PLAYBAR",
+            "S12"   =>  "PLAY:1",
             "ZP80"  =>  "ZONEPLAYER",
             "ZP90"  =>  "CONNECT",
             "ZP100" =>  "CONNECT:AMP",


### PR DESCRIPTION
Updated isSpeaker() to recognize newer PLAY:1's with the model number "S12".