### PR TITLE
Remove the test of text length

### DIFF
--- a/src/Tracks/TextToSpeech.php
+++ b/src/Tracks/TextToSpeech.php
@@ -36,10 +36,6 @@ class TextToSpeech implements UriInterface
      */
     public function __construct($text, Directory $directory, ProviderInterface $provider = null)
     {
-        if (strlen($text) > 100) {
-            throw new \InvalidArgumentException("Only messages under 100 characters are supported");
-        }
-
         $this->directory = $directory;
         $this->text = $text;
 


### PR DESCRIPTION
Is there a reall reason to make this test here ?

This test is already done in provider, with the right limit of the corresponding provider.
As an exemple, Acapela provider include a test of 300 characters, that can't be reach if only 100 allowed here.

Some other provider like PicoTTS also don't have this limit I think.