### PR TITLE
Update psr/log version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "duncan3dc/speaker": "^0.7.0",
         "guzzlehttp/guzzle": "^6.0",
         "league/flysystem": "^1.0",
-        "psr/log": "1.0.0",
+        "psr/log": "1.0.*",
         "ext-soap": "*",
         "ext-sockets": "*",
         "php": "^5.6|^7.0"


### PR DESCRIPTION
If other packages needs psr/log with a higher version of it, the installation fails.