### PR TITLE
Patch playbase

### DIFF
--- a/src/Device.php
+++ b/src/Device.php
@@ -183,6 +183,7 @@ class Device
             "S5"    =>  "PLAY:5",
             "S6"    =>  "PLAY:5",
             "S9"    =>  "PLAYBAR",
+            "S11"   =>  "PLAYBASE",
             "ZP80"  =>  "ZONEPLAYER",
             "ZP90"  =>  "CONNECT",
             "ZP100" =>  "CONNECT:AMP",


### PR DESCRIPTION
Hello Duncan,

This pull request is to add playbase support to you sonos Library.
S11 is the model number extrated from  http://XXX.XXX.XXX.XXX:1400/xml/device_description.xml

I don't know if the proposed change is enough to add support to the playbase or if you need to add other changes.
Unfortunatly, I will not be able to test the change. I don't own a playbase, but am asking this support on behalf of a forum user of a solution that is using you library. This users seems not skilled enough to be involved in testing.

Thanks in advance for your help.