### PR TITLE
delimiter Belkin Device

### DIFF
--- a/src/Network.php
+++ b/src/Network.php
@@ -200,13 +200,18 @@ class Network implements LoggerAwareInterface
         $this->logger->debug($response);
 
         $devices = [];
-        foreach (explode("\r\n\r\n", $response) as $reply) {
+        $replies = explode("\r\n\r\n", $response);
+        foreach ($replies  as $reply) {
             if (!$reply) {
                 continue;
             }
 
             $data = [];
-            foreach (explode("\r\n", $reply) as $line) {
+            $lines = explode("\r\n", $reply);
+            if (count($lines) == 1) {
+                $lines = explode("\n", $reply);
+            }
+            foreach ($lines as $line) {
                 if (!$pos = strpos($line, ":")) {
                     continue;
                 }


### PR DESCRIPTION
On my Network the Network->getDevices() funtion crashes.

Because the $device array does not have a "st" key.

`if ($device["st"] !== "urn:schemas-upnp-org:device:ZonePlayer:1") {`

the problem was that the $lines weren't exploded correctly because the delimiter is "\n" and not "\r\n"

![auswahl_050](https://user-images.githubusercontent.com/5549264/34763382-41bfb182-f5eb-11e7-802b-e7d457cd101d.png)

My Search response is:

```
HTTP/1.1 200 OK
CACHE-CONTROL: max-age = 1800
EXT:
LOCATION: http://192.168.11.5:1400/xml/device_description.xml
SERVER: Linux UPnP/1.0 Sonos/39.4-48021 (ZPS1)
ST: urn:schemas-upnp-org:device:ZonePlayer:1
USN: uuid:RINCON_5CAAFD4E6CC401400::urn:schemas-upnp-org:device:ZonePlayer:1
X-RINCON-HOUSEHOLD: Sonos_fw1Z6kcBa9ygugIWniiG8lF7Sy
X-RINCON-BOOTSEQ: 31
X-RINCON-WIFIMODE: 0
X-RINCON-VARIANT: 0
HOUSEHOLD.SMARTSPEAKER.AUDIO: Sonos_fw1Z6kcBa9ygugIWniiG8lF7Sy

HTTP/1.1 200 OK
CACHE-CONTROL: max-age=86400
DATE: 2016-10-29
EXT:
LOCATION: http://192.168.11.42:9500/db111907-d568-49d8-8218-7e26ecfbe2b5/setup.xml
OPT: "http://schemas.upnp.org/upnp/1/0/"; ns=01
01-NLS: 6764
SERVER: Unspecified, UPnP/1.0, Unspecified
ST: urn:Belkin:device:**
USN: uuid:Socket-1_0-db111907-d568-49d8-8218-7e26ecfbe2b5::urn:Belkin:device:**

HTTP/1.1 200 OK
CACHE-CONTROL: max-age=86400
DATE: 2016-10-29
EXT:
LOCATION: http://192.168.11.42:9501/ca62d5e0-3f52-4ceb-8f72-4d70d4fcd8b1/setup.xml
OPT: "http://schemas.upnp.org/upnp/1/0/"; ns=01
01-NLS: 6764
SERVER: Unspecified, UPnP/1.0, Unspecified
ST: urn:Belkin:device:**
USN: uuid:Socket-1_0-ca62d5e0-3f52-4ceb-8f72-4d70d4fcd8b1::urn:Belkin:device:**

HTTP/1.1 200 OK
CACHE-CONTROL: max-age=86400
DATE: 2016-10-29
EXT:
LOCATION: http://192.168.11.42:9502/e8c06259-a10e-4060-89a1-653c617b0d8e/setup.xml
OPT: "http://schemas.upnp.org/upnp/1/0/"; ns=01
01-NLS: 6764
SERVER: Unspecified, UPnP/1.0, Unspecified
ST: urn:Belkin:device:**
USN: uuid:Socket-1_0-e8c06259-a10e-4060-89a1-653c617b0d8e::urn:Belkin:device:**

HTTP/1.1 200 OK
CACHE-CONTROL: max-age = 1800
EXT:
LOCATION: http://192.168.11.77:1400/xml/device_description.xml
SERVER: Linux UPnP/1.0 Sonos/39.4-48021 (ZPS6)
ST: urn:schemas-upnp-org:device:ZonePlayer:1
USN: uuid:RINCON_5CAAFD0371D801400::urn:schemas-upnp-org:device:ZonePlayer:1
X-RINCON-HOUSEHOLD: Sonos_fw1Z6kcBa9ygugIWniiG8lF7Sy
X-RINCON-BOOTSEQ: 45
X-RINCON-WIFIMODE: 0
X-RINCON-VARIANT: 1
HOUSEHOLD.SMARTSPEAKER.AUDIO: Sonos_fw1Z6kcBa9ygugIWniiG8lF7Sy

HTTP/1.1 200 OK
CACHE-CONTROL: max-age = 1800
EXT:
LOCATION: http://192.168.11.28:1400/xml/device_description.xml
SERVER: Linux UPnP/1.0 Sonos/39.4-48021 (BR200)
ST: urn:schemas-upnp-org:device:ZonePlayer:1
USN: uuid:RINCON_B8E9370700AC01400::urn:schemas-upnp-org:device:ZonePlayer:1
X-RINCON-HOUSEHOLD: Sonos_fw1Z6kcBa9ygugIWniiG8lF7Sy
X-RINCON-BOOTSEQ: 21
X-RINCON-WIFIMODE: 0
X-RINCON-VARIANT: 0
HOUSEHOLD.SMARTSPEAKER.AUDIO: Sonos_fw1Z6kcBa9ygugIWniiG8lF7Sy

HTTP/1.1 200 OK
CACHE-CONTROL: max-age = 1800
EXT:
LOCATION: http://192.168.11.54:1400/xml/device_description.xml
SERVER: Linux UPnP/1.0 Sonos/39.4-48021 (ZPS3)
ST: urn:schemas-upnp-org:device:ZonePlayer:1
USN: uuid:RINCON_000E58F6EBAA01400::urn:schemas-upnp-org:device:ZonePlayer:1
X-RINCON-HOUSEHOLD: Sonos_fw1Z6kcBa9ygugIWniiG8lF7Sy
X-RINCON-BOOTSEQ: 22
X-RINCON-WIFIMODE: 0
X-RINCON-VARIANT: 0
HOUSEHOLD.SMARTSPEAKER.AUDIO: Sonos_fw1Z6kcBa9ygugIWniiG8lF7Sy
```