### PR TITLE
Adds the ability to add a playlist to the queue instead of multiple track uris

### DIFF
--- a/src/Interfaces/PlaylistInterface.php
+++ b/src/Interfaces/PlaylistInterface.php
@@ -36,6 +36,14 @@ interface PlaylistInterface extends QueueInterface
 
 
     /**
+     * Get the local file URI of the playlist
+     *
+     * @return string
+     */
+    public function getUri();
+
+
+    /**
      * Delete this playlist from the network.
      *
      * @return void

--- a/src/Interfaces/QueueInterface.php
+++ b/src/Interfaces/QueueInterface.php
@@ -4,6 +4,7 @@ namespace duncan3dc\Sonos\Interfaces;
 
 use duncan3dc\Sonos\Interfaces\TrackInterface;
 use duncan3dc\Sonos\Interfaces\UriInterface;
+use duncan3dc\Sonos\Playlist;
 
 /**
  * Provides an interface for managing the queue of a controller.
@@ -45,6 +46,16 @@ interface QueueInterface extends \Countable
      */
     public function addTracks(array $tracks, int $position = null): QueueInterface;
 
+    /**
+     * Add a sonos playlist to the queue.
+     *
+     * @param Playlist $playlist A playlist
+     * @param int $position The position to insert the tracks in the queue (zero-based),
+     *                      by default the tracks will be added to the end of the queue
+     *
+     * @return QueueInterface
+     */
+    public function addPlaylist(Playlist $playlist, $position = null): QueueInterface;
 
     /**
      * Remove a track from the queue.

--- a/src/Playlist.php
+++ b/src/Playlist.php
@@ -170,6 +170,16 @@ final class Playlist extends Queue implements PlaylistInterface
         return $this;
     }
 
+    /**
+     * Get local file URI from playlist
+     *
+     * @return string
+     */
+    public function getUri()
+    {
+        $playlistId = str_replace('SQ:','', $this->id);
+        return 'file:///jffs/settings/savedqueues.rsq#'.$playlistId;
+    }
 
     /**
      * Delete this playlist from the network.

--- a/src/Queue.php
+++ b/src/Queue.php
@@ -282,6 +282,37 @@ class Queue implements QueueInterface
         return $this;
     }
 
+    /**
+     * Add a sonos playlist to the queue.
+     *
+     * @param Playlist $playlist A playlist
+     * @param int $position The position to insert the tracks in the queue (zero-based),
+     *                      by default the tracks will be added to the end of the queue
+     *
+     * @return $this
+     */
+    public function addPlaylist(Playlist $playlist, $position = null): QueueInterface
+    {
+        if ($position === null) {
+            $position = $this->getNextPosition();
+        }
+
+        $numberOfTracks = count($playlist->getTracks());
+
+        $data = $this->soap("AVTransport", "AddURIToQueue", [
+            "UpdateID"                          =>  0,
+            "EnqueuedURI"                       =>  $playlist->getUri(),
+            "EnqueuedURIMetaData"               =>  '',
+            "DesiredFirstTrackNumberEnqueued"   =>  $position,
+            "EnqueueAsNext"                     =>  0,
+        ]);
+
+        if ($data["NumTracksAdded"] != $numberOfTracks) {
+            throw new SonosException("Failed to add all the tracks");
+        }
+
+        return $this;
+    }
 
     /**
      * Remove a track from the queue.


### PR DESCRIPTION
Adding a playlist with hundreds of tracks would take a long time because tracks are added in chunks of 16. This patch does a single add Uri with the playlist URI instead of the individual tracks which results in a massive speed up.