### PR TITLE
Add support for Spotify playlists

### DIFF
--- a/src/Helper.php
+++ b/src/Helper.php
@@ -12,6 +12,7 @@ class Helper
 {
     const TRACK_HASH = "00032020";
     const ALBUM_HASH = "0004206c";
+    const PLAYLIST_HASH = "0006006c";
 
     /**
      * Create a mode array from the mode text value.

--- a/src/Tracks/Factory.php
+++ b/src/Tracks/Factory.php
@@ -40,6 +40,7 @@ final class Factory implements FactoryInterface
     {
         $classes = [
             Spotify::class,
+            SpotifyPlaylist::class,
             Google::class,
             GoogleUnlimited::class,
             Deezer::class,

--- a/src/Tracks/SpotifyPlaylist.php
+++ b/src/Tracks/SpotifyPlaylist.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace duncan3dc\Sonos\Tracks;
+
+use duncan3dc\Sonos\Helper;
+
+/**
+ * Representation of a Spotify playlist.
+ */
+class SpotifyPlaylist extends Track
+{
+    const PREFIX = "x-rincon-cpcontainer:" . Helper::PLAYLIST_HASH;
+    const REGION_EU = "2311";
+    const REGION_US = "3079";
+
+    /**
+     * @var string $region The region code for the Spotify service (the default is EU).
+     */
+    public static $region = self::REGION_EU;
+
+
+    /**
+     * Create a Spotify playlist object.
+     *
+     * @param string $uri The URI of the playlist or the full Spotify ID of the playlist
+     */
+    public function __construct(string $uri)
+    {
+        # If this is a spotify playlist ID and not a URI then convert it to a URI now
+        if (substr($uri, 0, strlen(self::PREFIX)) !== self::PREFIX) {
+            $uri = self::PREFIX . urlencode($uri);
+        }
+
+        parent::__construct($uri);
+    }
+
+    /**
+     * Get the metadata xml for this playlist.
+     *
+     * @return string
+     */
+    public function getMetaData(): string
+    {
+        $uri = substr($this->getUri(), strlen(self::PREFIX));
+
+        return Helper::createMetaDataXml(Helper::PLAYLIST_HASH . "{$uri}", "-1", [
+            "dc:title"      =>  "",
+            "upnp:class"    =>  "object.container.playlistContainer",
+        ], static::$region);
+    }
+}

--- a/src/Tracks/SpotifyPlaylist.php
+++ b/src/Tracks/SpotifyPlaylist.php
@@ -9,7 +9,7 @@ use duncan3dc\Sonos\Helper;
  */
 class SpotifyPlaylist extends Track
 {
-    const PREFIX = "x-rincon-cpcontainer:" . Helper::PLAYLIST_HASH;
+    const PREFIX = "x-rincon-cpcontainer:";
     const REGION_EU = "2311";
     const REGION_US = "3079";
 
@@ -28,7 +28,7 @@ class SpotifyPlaylist extends Track
     {
         # If this is a spotify playlist ID and not a URI then convert it to a URI now
         if (substr($uri, 0, strlen(self::PREFIX)) !== self::PREFIX) {
-            $uri = self::PREFIX . urlencode($uri);
+            $uri = self::PREFIX . Helper::PLAYLIST_HASH . urlencode($uri);
         }
 
         parent::__construct($uri);
@@ -43,7 +43,7 @@ class SpotifyPlaylist extends Track
     {
         $uri = substr($this->getUri(), strlen(self::PREFIX));
 
-        return Helper::createMetaDataXml(Helper::PLAYLIST_HASH . "{$uri}", "-1", [
+        return Helper::createMetaDataXml($uri, "-1", [
             "dc:title"      =>  "",
             "upnp:class"    =>  "object.container.playlistContainer",
         ], static::$region);

--- a/tests/Tracks/FactoryTest.php
+++ b/tests/Tracks/FactoryTest.php
@@ -9,6 +9,7 @@ use duncan3dc\Sonos\Tracks\Factory;
 use duncan3dc\Sonos\Tracks\Google;
 use duncan3dc\Sonos\Tracks\GoogleUnlimited;
 use duncan3dc\Sonos\Tracks\Spotify;
+use duncan3dc\Sonos\Tracks\SpotifyPlaylist;
 use duncan3dc\Sonos\Tracks\Stream;
 use duncan3dc\Sonos\Tracks\Track;
 use duncan3dc\SonosTests\MockTest;
@@ -43,6 +44,13 @@ class FactoryTest extends MockTest
         $this->assertInstanceOf(Spotify::class, $track);
     }
 
+
+    public function testSpotifyPlaylistUri()
+    {
+        $uri = "x-rincon-cpcontainer:0006006cspotify:user:123sdfd6:playlist:123sdfd6";
+        $track = $this->factory->createFromUri($uri);
+        $this->assertInstanceOf(SpotifyPlaylist::class, $track);
+    }
 
     public function testDeezerTrackUri()
     {
@@ -103,6 +111,14 @@ class FactoryTest extends MockTest
         $xml = $this->getXml("x-sonos-spotify:spotify:track:123sdfd6");
         $track = $this->factory->createFromXml($xml);
         $this->assertInstanceOf(Spotify::class, $track);
+    }
+
+
+    public function testSpotifyPlaylistTrackXml()
+    {
+        $xml = $this->getXml("x-rincon-cpcontainer:0006006cspotify:user:123sdfd6:playlist:123sdfd6");
+        $track = $this->factory->createFromXml($xml);
+        $this->assertInstanceOf(SpotifyPlaylist::class, $track);
     }
 
 


### PR DESCRIPTION
I'm not really a fan of my implementation here as I'm somewhat masquerading a collection of tracks as a single `Track` object, however it seems that the library doesn't have a concept of a "Playlist" yet (although this is something that #98 may change).

I've left a comment or two below regarding my changes.

Fixes #56.