### PR TITLE
Improve PHPUnit fixtures

### DIFF
--- a/tests/Devices/CachedCollectionTest.php
+++ b/tests/Devices/CachedCollectionTest.php
@@ -15,7 +15,7 @@ class CachedCollectionTest extends TestCase
     private $cache;
     private $cachedCollection;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->collection = Mockery::mock(CollectionInterface::class);
         $this->cache = Mockery::mock(CacheInterface::class);
@@ -23,7 +23,7 @@ class CachedCollectionTest extends TestCase
     }
 
 
-    public function tearDown()
+    protected function tearDown()
     {
         Mockery::close();
     }

--- a/tests/Devices/CollectionTest.php
+++ b/tests/Devices/CollectionTest.php
@@ -13,14 +13,14 @@ class CollectionTest extends TestCase
     private $factory;
     private $collection;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->factory = Mockery::mock(FactoryInterface::class);
         $this->collection = new Collection($this->factory);
     }
 
 
-    public function tearDown()
+    protected function tearDown()
     {
         Mockery::close();
     }

--- a/tests/Devices/DiscoveryTest.php
+++ b/tests/Devices/DiscoveryTest.php
@@ -17,7 +17,7 @@ class DiscoveryTest extends TestCase
     private $collection;
     private $discovery;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->collection = Mockery::mock(CollectionInterface::class);
         $this->collection->shouldReceive("getLogger")->with()->andReturn(new NullLogger());
@@ -27,7 +27,7 @@ class DiscoveryTest extends TestCase
     }
 
 
-    public function tearDown()
+    protected function tearDown()
     {
         Mockery::close();
     }

--- a/tests/Devices/FactoryTest.php
+++ b/tests/Devices/FactoryTest.php
@@ -11,7 +11,7 @@ use Psr\SimpleCache\CacheInterface;
 
 class FactoryTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown()
     {
         Mockery::close();
     }

--- a/tests/LiveTest.php
+++ b/tests/LiveTest.php
@@ -12,7 +12,7 @@ abstract class LiveTest extends TestCase
     /** @var NetworkInterface */
     protected $network;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->network = new Network();
 

--- a/tests/MockTest.php
+++ b/tests/MockTest.php
@@ -15,12 +15,12 @@ abstract class MockTest extends TestCase
 {
     protected $network;
 
-    public function tearDown()
+    protected function tearDown()
     {
         Mockery::close();
     }
 
-    public function setUp()
+    protected function setUp()
     {
         $this->network = Mockery::mock(NetworkInterface::class);
 

--- a/tests/NetworkTest.php
+++ b/tests/NetworkTest.php
@@ -20,14 +20,14 @@ class NetworkTest extends MockTest
     private $collection;
 
 
-    public function setUp()
+    protected function setUp()
     {
         $this->collection = Mockery::mock(CollectionInterface::class);
         $this->network = new Network($this->collection);
     }
 
 
-    public function tearDown()
+    protected function tearDown()
     {
         Mockery::close();
     }

--- a/tests/PlaylistLiveTest.php
+++ b/tests/PlaylistLiveTest.php
@@ -10,7 +10,7 @@ class PlaylistLiveTest extends LiveTest
     protected $playlist;
     protected $playlistName = "phpunit-test";
 
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
 
@@ -22,7 +22,7 @@ class PlaylistLiveTest extends LiveTest
     }
 
 
-    public function tearDown()
+    protected function tearDown()
     {
         if ($this->playlist) {
             $this->playlist->delete();

--- a/tests/QueueLiveTest.php
+++ b/tests/QueueLiveTest.php
@@ -10,7 +10,7 @@ class QueueLiveTest extends LiveTest
     protected $queue;
     protected $state;
 
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
 
@@ -27,7 +27,7 @@ class QueueLiveTest extends LiveTest
     }
 
 
-    public function tearDown()
+    protected function tearDown()
     {
         if ($this->controller) {
             $this->controller->restoreState($this->state);

--- a/tests/QueueTest.php
+++ b/tests/QueueTest.php
@@ -14,7 +14,7 @@ class QueueTest extends MockTest
     protected $controller;
     protected $queue;
 
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
 
@@ -23,7 +23,7 @@ class QueueTest extends MockTest
         $this->queue = new Queue($this->controller);
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         Mockery::close();
     }

--- a/tests/Services/RadioTest.php
+++ b/tests/Services/RadioTest.php
@@ -19,7 +19,7 @@ class RadioTest extends MockTest
     private $radio;
 
 
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
 

--- a/tests/SpeakerLiveTest.php
+++ b/tests/SpeakerLiveTest.php
@@ -6,7 +6,7 @@ class SpeakerLiveTest extends LiveTest
 {
     protected $speaker;
 
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
         $speakers = $this->network->getSpeakers();

--- a/tests/SpeakerTest.php
+++ b/tests/SpeakerTest.php
@@ -11,7 +11,7 @@ class SpeakerTest extends MockTest
     protected $device;
     protected $speaker;
 
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
 
@@ -19,7 +19,7 @@ class SpeakerTest extends MockTest
         $this->speaker = $this->getSpeaker($this->device);
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         Mockery::close();
     }

--- a/tests/StateTest.php
+++ b/tests/StateTest.php
@@ -10,7 +10,7 @@ use Mockery;
 
 class StateTest extends TrackTest
 {
-    public function setUp()
+    protected function setUp()
     {
         $controller = Mockery::mock(ControllerInterface::class);
         $controller->shouldReceive("getIp")->andReturn("192.168.0.66");

--- a/tests/Tracks/FactoryTest.php
+++ b/tests/Tracks/FactoryTest.php
@@ -18,7 +18,7 @@ class FactoryTest extends MockTest
     /** @var Factory */
     private $factory;
 
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
 

--- a/tests/Tracks/TrackTest.php
+++ b/tests/Tracks/TrackTest.php
@@ -34,7 +34,7 @@ XML;
     protected $track1;
     protected $track2;
 
-    public function setUp()
+    protected function setUp()
     {
         $controller = Mockery::mock(ControllerInterface::class);
         $controller->shouldReceive("getIp")->with()->andReturn("192.168.0.66");
@@ -47,7 +47,7 @@ XML;
     }
 
 
-    public function tearDown()
+    protected function tearDown()
     {
         Mockery::close();
     }

--- a/tests/Utils/DirectoryTest.php
+++ b/tests/Utils/DirectoryTest.php
@@ -15,13 +15,13 @@ class DirectoryTest extends TestCase
     private $filesystem;
 
 
-    public function setUp()
+    protected function setUp()
     {
         $this->filesystem = Mockery::mock(FilesystemInterface::class);
     }
 
 
-    public function tearDown()
+    protected function tearDown()
     {
         Mockery::close();
     }


### PR DESCRIPTION
# Changed log

- According to the official [PHPUnit doc](https://phpunit.de/manual/6.5/en/fixtures.html#fixtures.more-setup-than-teardown), it should be `protected function setUp` and `protected function tearDown` methods.