### PR TITLE
Full support for PHP 8.2 and Symfony 6.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
         "duncan3dc/speaker": "^1.0",
         "guzzlehttp/guzzle": "^6.0",
         "league/flysystem": "^1.1.4",
-        "psr/log": "^1.1",
-        "psr/simple-cache": "^1.0",
+        "psr/log": "^3.0 || ^1.0",
+        "psr/simple-cache": "^3.0 || ^1.0",
         "ext-soap": "*",
         "ext-sockets": "*",
         "php": "^7.3 || ^8.0"


### PR DESCRIPTION
Change psr requirements to fully support PHP 8.2 ans Symfony 6.2

Change :
`        "psr/log": "^1.0",`
`        "psr/simple-cache": "^1.0",`

To : 
`        "psr/log": "^3.0 || ^1.0",`
`        "psr/simple-cache": "^3.0 || ^1.0",`

