### PR TITLE
Add new/updated SYMFONISK Bookshelf version reporting model "S33"

### DIFF
--- a/src/Devices/Device.php
+++ b/src/Devices/Device.php
@@ -213,6 +213,7 @@ final class Device implements DeviceInterface
             "S19" => "ARC",
             "S20" => "SYMFONISK Table Lamp",
             "S21" => "SYMFONISK Bookshelf",
+            "S33" => "SYMFONISK Bookshelf",
             "S29" => "SYMFONISK Picture Frame",
             "S22" => "ONE SL",
             "S38" => "ONE SL",

--- a/tests/Devices/DeviceTest.php
+++ b/tests/Devices/DeviceTest.php
@@ -36,6 +36,7 @@ class DeviceTest extends MockTest
             "S27",
             "S29",
             "S31",
+            "S33",
             "S35",
             "S38",
             "ZP80",


### PR DESCRIPTION
I found my SYMFONISK Bookshelf speakers are now reporting model "S33", not sure since when. They work again after adding the model number.